### PR TITLE
Option to left align URL bar and collapse extension identity box

### DIFF
--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -368,11 +368,17 @@ toolbarspring {
 #urlbar-input::placeholder,
 .searchbar-textbox::placeholder {
   font-size: 12.5px !important;
-  text-align: left !important;
+  text-align: center !important;
+  @media -moz-pref("gwfox.alignLeft") {
+    text-align: left !important;
+  }
 }
 
 #urlbar-input {
   text-align: center !important;
+  @media -moz-pref("gwfox.alignLeft") {
+    text-align: left !important;
+  }
   margin-bottom: 1px !important;
 }
 
@@ -417,6 +423,9 @@ toolbarspring {
 #urlbar-input::placeholder {
   font-size: 21px !important;
   text-align: center !important;
+  @media -moz-pref("gwfox.alignLeft") {
+    text-align: left !important;
+  }
 }
 
 .urlbar-input-container {
@@ -3626,4 +3635,9 @@ tab-group[collapsed] > .tab-group-label-container > & {
 }
 }
 }
+}
+
+#identity-box.extensionPage #identity-icon-labels,
+#identity-box.extensionPage #identity-icon-label {
+  visibility: collapse !important;
 }

--- a/user.js
+++ b/user.js
@@ -15,4 +15,5 @@ user_pref("browser.tabs.allow_transparent_browser", false);
 /* (可选项 | OPTIONAL) */
 
 user_pref("gwfox.plus", false);
+user_pref("gwfox.alignLeft", false);
 /*user_pref("widget.macos.native-context-menus", true);*/


### PR DESCRIPTION
# Proposal to fix two issues related to the URL bar:

## Issue 1: 
Solving #35, collapse extension identity box in URL bar. This fixes the overly large identity box when using extensions such as Bonjourr.

## Issue 2: 
On some devices, the center aligned text in the URL bar causes weird visual problems and weird cursor placement, especially when not using `gwfox.plus`. These problems are fixed by left aligning the text in the URL bar as is default in Firefox. 

I understand that the center aligned URL bar is a key visual part of this CSS. In order to retain this, but give the option to left align the text, I have created a new `about:config` variable that is default set to `false`. When set to `true`, the text in the URL bar will be left aligned, fixing some visual issues for some users.